### PR TITLE
Various Updates to 1KC README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,139 @@
 <div align="center">
-<h1>1KC: One Thousand Contributors Program</h1>
+<img align="center" src="https://user-images.githubusercontent.com/25497083/152479229-28d8a2d9-3158-4742-aff9-e8860dce11ca.png" width="500">
+<h1>One Thousand Contributors Programme</h1>
 <br>
 </div>
 
-![1KC](assets/one-thousand-contributors-program.png)
 
-## What is the 1KC?
+- [Introduction](#introduction)
+- [How to Participate](#how-to-participate)
+  - [Process](#process)
+  - [Submission reviews](#submission-reviews)
+- [Roadmap](#roadmap)
+  - [Stage 1: Pilot](#stage-1-pilot)
+  - [Stage 2: Scaling](#stage-2-scaling)
+  - [Stage 3: Decentralize](#stage-3-decentralize)
+- [1KC Evaluators](#1kc-evaluators)
+- [Alternative Funding Sources](#alternative-funding-sources)
+  - [Treasury](#treasury)
+- [License](#license)
+<!-- /TOC -->
+---
 
-The Technical Education, Community, and Support (TCS) team(s) of the Web3 Foundation and Parity are 
-launching an off-chain contributor program to support our community and contributors. We hope to start 
-small with this program and learn as we go. Our intent is to be transparent as possible and even though
-it will be centralized at first, overtime with feedback from our participants, we plan to decentralize
-this project with hopes to move things on-chain as it makes sense. Think about the Polkadot launch,
-it started as a Proof of Authority(PoA) network, and without any other functionality than ability to
-create blocks with nodes controlled by the Web3 Foundation. Slowly we started releasing features that
-allowed the network to be more decentralized, such as ability to become a validator, and then governance,
-followed by balance transfers etc. With the same intentin in mind, we hope that you will be excited to help
-us develop this program further!
+## Introduction
 
-For contributors, there are on-chain funding avenues through
-[Treasury Proposals](https://wiki.polkadot.network/docs/learn-treasury#creating-a-treasury-proposal) 
-proposals and [Tipping](https://wiki.polkadot.network/docs/learn-treasury#tipping).
+The Technical Education and Support teams of the Web3 Foundation, along with the Community team 
+at Parity Technologies offer an off-chain contributor program to support and fund community 
+contributions. As part of our commitment to promoting the WEB3 ecosystem, this program focuses on 
+funding contributions in the areas of **Technical Education**, **Community** and 
+**Support** that relates to the Polkadot ecosystem.
 
-The TCS team is offering another avenue to reward contributions that may encounter difficulties 
-in existing funding methods, namely smaller contributions. In particular, the contributors program 
-aims to capture contributions in the areas of **Technical Education**, **Community** and **Support**. 
+The program, One Thousand Contributors Programme or 1KC for short, takes motivation from the 
+[Thousand Validators Programme (1KV)](https://github.com/w3f/1k-validators-be) and the 
+[Web3 Foundation Grants Program](https://github.com/w3f/Grants-Program).
 
-It is our belief that this program will foster more engagement and contribution, while embarking 
-on the WEB3 vision, we need all the help that we can get.
- 
-> The 1KC Program will help us build a stronger bond with our community and facilitate the creation 
-> of quality content.
+> The 1KC program is managed by the Technical Education & Support teams of Web3 Foundation.
+> For more information about Web3 Foundation, please visit the [About page](https://web3.foundation/about/) 
+> on our website.
 
 ## How to Participate
 
 You can signal your intent to participate by choosing a task from this [list](https://github.com/orgs/w3f/projects/13)
-of open tasks, and filling out [this](https://form.typeform.com/to/I9vjnCcI) typeform we have created for you :)
+of open tasks, and then filling out this [typeform](https://form.typeform.com/to/I9vjnCcI).
 
-## Process
+### Process
 
-The first step is filling out the typeform, once we have your proposal we will:
+Once you have submitted your contribution proposal, the team will:
 
-1. Evaluate. Depending on which area you want to contribute your evaluators will be different.
-2. Accept or deny. Once we review your proposal, we will get in touch with you about the status.
-3. Define your delivery. All tasks will have different delivery requirements, we will clearly communicate
-to you what your contribution will be required to fulfill.
-4. Funding. Once the delivery of the task has been finalized, we will deposit your rewards to the account
-that you shared with us.
+1. Evaluate. Your [evaluators](#1kc-evaluators) will differ depending on which area you want to contribute.
+3. Accept or deny. Once we review your proposal, we will get in touch with you about the status.
+4. Define your delivery. All tasks will have different delivery requirements; we will communicate what your 
+contribution needs to fulfill.
+5. Funding. Once the delivery of the task has been finalized, we will deposit your rewards to the account
+shared with us.
 
-## Team and Evaluators
+### Submission reviews
 
-Members of the Technical Education, Community and Support Teams at Web3 Foundation & Parity
-Technologies will be the program curators and maintainers, in the form of **1KC Evaluators**
+The review process follows the pipeline in the [1KC public GitHub project](https://github.com/orgs/w3f/projects/13).
+
+## Roadmap
+
+### Stage 1: Pilot
+
+*Pilot the program within more general conditions, with non-adversarial participants.*
+
+- Discover and understand the bottlenecks of this program.
+- Contributors of varying backgrounds and levels of expertise can submit contributions. These contributions will be 
+subject to compliance with established guidelines outlined in this document and high levels of scrutiny.
+
+The team initially launched the program as a pilot program with an estimated duration of around 14 weeks, where tasks 
+are outlined by Web3 Foundation and made publically available. 
+
+**Target Audience**: Ambassadors that are part of the [Polkadot 
+Ambassador Programme](https://wiki.polkadot.network/docs/ambassadors) and active ecosystem members.
+
+The purpose of this is to test out the program through active community members and reward existing contributors.
+
+### Stage 2: Scaling
+
+*Scale the program within greater conditions, with adversarial participants.*
+
+- Iterate portions subject to change based on lessons from the pilot program.
+- Extend the program to the general community.
+- Create an official landing page.
+- Increase funding amount.
+
+After the pilot program, the team intends to scale this to a grants-proposal model, where the community can propose 
+any new ideas. 
+
+**Target Audience**: All types of Polkadot community members.
+
+### Stage 3: Decentralize
+
+*Decentralize the program within grand conditions, with all participants.*
+
+The program starts small with the goal to learn as we go. We plan to decentralize
+this programme and consider moving the program on-chain, as it makes sense. 
+
+> Similar to the Polkadot launch; Polkadot started as a Proof of Authority (PoA) network, without any other functionality 
+> than the ability to create blocks with nodes controlled by Web3 Foundation. Slowly, we started releasing features 
+> that allowed the network to be more decentralized, such as the ability to become a validator, and then governance,
+> followed by balance transfers, etc. We hope you will be excited to help us develop this program further with the 
+> same intent in mind.
+
+**Target Audience**: The entire Polkadot ecosystem.
+
+## 1KC Evaluators
+
+1KC Evaluators are individuals able to evaluate the contribution delivered from  the Contributors Programme. 
 
 - Supervisor: Bill Laboon
-- Technical Education: Radhakrishna Dasari, Emre Surmeli & Danny Salman
-- Community: Elodie Dincuff & Urban Osvald
-- Support: Michalis Fragkiadakis, Keegan Quigley & Anja Schuetz
+- Technical Education: 
+  - Radhakrishna Dasari: Media related contributions 
+  - Emre Surmeli: Communinty related contributions
+  - Danny Salman: Documentation related contributions
+- Support: 
+  - Michalis Fragkiadakis: Support related contributions
+
+The 1KC evaluators will reach out to Subject Matter Experts within Web3 Foundation where a niche expert opinion is desirable.
+As the program is currently in a pilot model, an official committee will be established when the time is appropriate.
+ 
+## Alternative Funding Sources
+ 
+We encourage you to explore the alternative funding options listed below. Please note, however, that you should not seek to fund 
+the exact scope of work from multiple sources and that any team found doing so will have its Web3 Foundation support terminated.
+
+### Treasury
+
+The treasury is a pot of on-chain funds collected through transaction fees, slashing, staking inefficiencies, etc. The funds held 
+in the treasury can be spent on spending proposals. Both [Polkadot](https://polkadot.network/) and [Kusama](https://kusama.network/) 
+offer everyone the opportunity to apply for funding via the treasury. 
+See:
+
+- [Treasury Wiki](https://wiki.polkadot.network/docs/en/learn-treasury)
+- [Polkadot Treasury Guide](https://docs.google.com/document/d/1IZykdp2cyQavcRyZd_dgNj5DcgxgZR6kAqGdcNARu1w)
+- [Kusama Treasury Guide](https://docs.google.com/document/d/1p3UQUjph5t8TVaWnTkfrI5mE-BABnM9Xvtuhdlhl6JE)
+
+## License
+
+[Apache License 2.0](LICENSE) © Web3 Foundation

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 The Technical Education and Support teams of the Web3 Foundation, along with the Community team 
 at Parity Technologies offer an off-chain contributor program to support and fund community 
 contributions. As part of our commitment to promoting the WEB3 ecosystem, this program focuses on 
-funding contributions in the areas of **Technical Education**, **Community** and 
-**Support** that relates to the Polkadot ecosystem.
+funding contributions in the areas of **technical education**, **community** and 
+**support** that relates to the Polkadot ecosystem.
 
 The program, One Thousand Contributors Programme or 1KC for short, takes motivation from the 
 [Thousand Validators Programme (1KV)](https://github.com/w3f/1k-validators-be) and the 
@@ -65,8 +65,16 @@ The review process follows the present pipeline in the [1KC public GitHub projec
 - Contributors of varying backgrounds and levels of expertise can submit contributions. These contributions will be 
 subject to compliance with established guidelines outlined in this document and high levels of scrutiny.
 
-The team initially launched the program as a pilot program with an estimated duration of around 14 weeks, where tasks 
-are outlined by Web3 Foundation and made publically available. 
+The team initially launched the program as a pilot program, where tasks are outlined by Web3 Foundation and made 
+publically available.
+
+The team uses this program as an off-chain reward mechanism to reward specific contributions from 
+the community. We believe this is supplementary to the on-chain treasury and bounties, which don't reward 
+specific contributions easily. See [Alternative Funding Sources](#alternative-funding-sources) for more details on 
+traditional funding methods.
+
+> However, the program also serves as an opportunity to encourage contributions in the areas of technical 
+> education, community, and support for the Polkadot ecosystem.
 
 **Target Audience**: Ambassadors that are part of the [Polkadot 
 Ambassador Programme](https://wiki.polkadot.network/docs/ambassadors) and active ecosystem members.

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ The review process follows the present pipeline in the [1KC public GitHub projec
 
 ### Stage 1: Pilot
 
-*Pilot the program within more general conditions, for non-adversarial participants.*
+*Pilot the program with limited conditions*
 
 - Discover and understand the bottlenecks of this program.
 - Contributors of varying backgrounds and levels of expertise can submit contributions. These contributions will be 
 subject to compliance with established guidelines outlined in this document and high levels of scrutiny.
 
 The team initially launched the program as a pilot program, where tasks are outlined by Web3 Foundation and made 
-publically available.
+publicly.
 
 The team uses this program as an off-chain reward mechanism to reward specific contributions from 
 the community. We believe this is supplementary to the on-chain treasury and bounties, which don't reward 
@@ -83,21 +83,21 @@ The purpose of this is to test out the program through active community members 
 
 ### Stage 2: Scale
 
-*Scale the program within greater conditions, for adversarial participants.*
+*Scale the program with greater conditions*
 
-- Iterate portions subject to change based on lessons from the pilot program.
+- Apply improvements based on lessons from the pilot program.
 - Extend the program to the general community.
 - Create an official landing page.
 - Increase funding amount.
 
 After the pilot program, the team intends to scale this to a grants-proposal model, where the community can propose 
-any new ideas. 
+new ideas. 
 
 **Target Audience**: All types of Polkadot community members.
 
 ### Stage 3: Decentralize
 
-*Decentralize the program without previous conditions, for all participants.*
+*Decentralize the program with modified conditions*
 
 The program starts small with the goal to learn as we go. We plan to decentralize
 this programme and consider moving the program on-chain, as it makes sense. 
@@ -122,13 +122,14 @@ this programme and consider moving the program on-chain, as it makes sense.
 - Support: 
   - [Michalis Fragkiadakis](https://github.com/michalisFr): Support related contributions
 
-The 1KC evaluators will reach out to Subject Matter Experts within Web3 Foundation where a niche expert opinion is desirable.
-As the program is currently in a pilot model, an official committee will be established when the time is appropriate.
+The 1KC evaluators will reach out to Subject Matter Experts within Web3 Foundation where a niche expert opinion is 
+desirable. As the program is currently in a pilot model, an official committee will be established when the time is 
+appropriate.
  
 ## Alternative Funding Sources
  
-We encourage you to explore the alternative funding options listed below. Please note, however, that you should not seek to fund 
-the exact scope of work from multiple sources and that any team found doing so will have its Web3 Foundation support terminated.
+We encourage you to explore the alternative funding options listed below. Please note, however, that you should not 
+seek to fund the same work from multiple sources. Anyone found doing so will be terminated from 1KC program.
 
 ### Treasury
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   - [Submission reviews](#submission-reviews)
 - [Roadmap](#roadmap)
   - [Stage 1: Pilot](#stage-1-pilot)
-  - [Stage 2: Scaling](#stage-2-scaling)
+  - [Stage 2: Scale](#stage-2-scale)
   - [Stage 3: Decentralize](#stage-3-decentralize)
 - [1KC Evaluators](#1kc-evaluators)
 - [Alternative Funding Sources](#alternative-funding-sources)
@@ -45,21 +45,21 @@ of open tasks, and then filling out this [typeform](https://form.typeform.com/to
 Once you have submitted your contribution proposal, the team will:
 
 1. Evaluate. Your [evaluators](#1kc-evaluators) will differ depending on which area you want to contribute.
-3. Accept or deny. Once we review your proposal, we will get in touch with you about the status.
-4. Define your delivery. All tasks will have different delivery requirements; we will communicate what your 
+2. Accept or deny. Once we review your proposal, we will get in touch with you about the status.
+3. Define your delivery. All tasks will have different delivery requirements; we will communicate what your 
 contribution needs to fulfill.
-5. Funding. Once the delivery of the task has been finalized, we will deposit your rewards to the account
+4. Funding. Once both parties finalize the delivery of the task, the team will deposit your rewards to the account
 shared with us.
 
 ### Submission reviews
 
-The review process follows the pipeline in the [1KC public GitHub project](https://github.com/orgs/w3f/projects/13).
+The review process follows the present pipeline in the [1KC public GitHub project](https://github.com/orgs/w3f/projects/13).
 
 ## Roadmap
 
 ### Stage 1: Pilot
 
-*Pilot the program within more general conditions, with non-adversarial participants.*
+*Pilot the program within more general conditions, for non-adversarial participants.*
 
 - Discover and understand the bottlenecks of this program.
 - Contributors of varying backgrounds and levels of expertise can submit contributions. These contributions will be 
@@ -73,9 +73,9 @@ Ambassador Programme](https://wiki.polkadot.network/docs/ambassadors) and active
 
 The purpose of this is to test out the program through active community members and reward existing contributors.
 
-### Stage 2: Scaling
+### Stage 2: Scale
 
-*Scale the program within greater conditions, with adversarial participants.*
+*Scale the program within greater conditions, for adversarial participants.*
 
 - Iterate portions subject to change based on lessons from the pilot program.
 - Extend the program to the general community.
@@ -89,7 +89,7 @@ any new ideas.
 
 ### Stage 3: Decentralize
 
-*Decentralize the program within grand conditions, with all participants.*
+*Decentralize the program within greater conditions, for all participants.*
 
 The program starts small with the goal to learn as we go. We plan to decentralize
 this programme and consider moving the program on-chain, as it makes sense. 
@@ -104,7 +104,7 @@ this programme and consider moving the program on-chain, as it makes sense.
 
 ## 1KC Evaluators
 
-1KC Evaluators are individuals able to evaluate the contribution delivered from  the Contributors Programme. 
+1KC Evaluators are individuals able to evaluate the contribution delivered from the Contributors Programme. 
 
 - Supervisor: [Bill Laboon](https://github.com/laboon)
 - Technical Education: 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <img align="center" src="https://user-images.githubusercontent.com/25497083/152479229-28d8a2d9-3158-4742-aff9-e8860dce11ca.png" width="500">
-<h1>One Thousand Contributors Programme</h1>
+<h1>Thousand Contributors Programme</h1>
 <br>
 </div>
 
@@ -89,7 +89,7 @@ any new ideas.
 
 ### Stage 3: Decentralize
 
-*Decentralize the program within greater conditions, for all participants.*
+*Decentralize the program without previous conditions, for all participants.*
 
 The program starts small with the goal to learn as we go. We plan to decentralize
 this programme and consider moving the program on-chain, as it makes sense. 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 <br>
 </div>
 
-
 - [Introduction](#introduction)
 - [How to Participate](#how-to-participate)
   - [Process](#process)
@@ -107,13 +106,13 @@ this programme and consider moving the program on-chain, as it makes sense.
 
 1KC Evaluators are individuals able to evaluate the contribution delivered from  the Contributors Programme. 
 
-- Supervisor: Bill Laboon
+- Supervisor: [Bill Laboon](https://github.com/laboon)
 - Technical Education: 
-  - Radhakrishna Dasari: Media related contributions 
-  - Emre Surmeli: Communinty related contributions
-  - Danny Salman: Documentation related contributions
+  - [Radhakrishna Dasari](https://github.com/DrW3RK): Media related contributions 
+  - [Emre Surmeli](https://github.com/emresurmeli): Communinty related contributions
+  - [Danny Salman](https://github.com/DannyS03): Documentation related contributions
 - Support: 
-  - Michalis Fragkiadakis: Support related contributions
+  - [Michalis Fragkiadakis](https://github.com/michalisFr): Support related contributions
 
 The 1KC evaluators will reach out to Subject Matter Experts within Web3 Foundation where a niche expert opinion is desirable.
 As the program is currently in a pilot model, an official committee will be established when the time is appropriate.


### PR DESCRIPTION
- Creates a **temporary** logo to avoid confusion with the thousand validators programme
- Adds more scope to the program to point out the key features
- Adds roadmap
- Limits evaluators to the ones specified for the pilot, so program maintainers and points of contact are clear
- Adds a better tone for the program's presentation + communicates the info in present-tense & with more of an active voice

resolves #4 